### PR TITLE
Product 도메인 crud 구현

### DIFF
--- a/logistics/src/main/java/msa/logistics/service/logistics/common/entity/BaseEntity.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/common/entity/BaseEntity.java
@@ -3,6 +3,7 @@ package msa.logistics.service.logistics.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedBy;
@@ -46,5 +47,13 @@ public abstract class BaseEntity implements Serializable {
 
     @Column(name = "is_delete")
     protected Boolean isDelete;
+
+    // is_delete 기본값 false로 설정
+    @PrePersist
+    protected void onCreate() {
+        if (this.isDelete == null) {
+            this.isDelete = false;
+        }
+    }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/common/exception/ErrorCode.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/common/exception/ErrorCode.java
@@ -8,6 +8,9 @@ public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     RESPONSE_NOT_FOUND(HttpStatus.NOT_FOUND, "응답을 찾을 수 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
+    VENDOR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 업체를 찾을 수 없습니다."),
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 허브를 찾을 수 없습니다."),
 
 
     // ------ 5xx ------

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -38,6 +39,15 @@ public class ProductController {
     public ResponseEntity<ApiResponseDto<ProductResponseDto>> getProduct(@PathVariable UUID productId) {
         ProductResponseDto product = productService.getProduct(productId);
         return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "상품 상세 정보 조회 성공", product));
+    }
+
+    /**
+     * 특정 업체의 상품 목록 조회
+     */
+    @GetMapping("/vendors/{vendorId}")
+    public ResponseEntity<ApiResponseDto<List<ProductResponseDto>>> getProductsByVendor(@PathVariable UUID vendorId) {
+        List<ProductResponseDto> products = productService.getProductsByVendor(vendorId);
+        return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "업체의 전체 상품 목록", products));
     }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
@@ -1,4 +1,15 @@
 package msa.logistics.service.logistics.product.controller;
 
+import lombok.RequiredArgsConstructor;
+import msa.logistics.service.logistics.product.service.ProductService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
 public class ProductController {
+
+    private final ProductService productService;
+
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
@@ -4,13 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import msa.logistics.service.logistics.common.dto.ApiResponseDto;
 import msa.logistics.service.logistics.product.dto.request.ProductCreateRequestDto;
+import msa.logistics.service.logistics.product.dto.response.ProductResponseDto;
 import msa.logistics.service.logistics.product.service.ProductService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.UUID;
@@ -30,7 +28,16 @@ public class ProductController {
         UUID productId = productService.createProduct(request);
         return ResponseEntity
                 .created(URI.create("/api/v1/products/" + productId))
-                .body(new ApiResponseDto<>(HttpStatus.CREATED, "상품이 생성되었습니다.", productId));
+                .body(new ApiResponseDto<>(HttpStatus.CREATED, "상품 생성 성공", productId));
+    }
+
+    /**
+     * 상품 상세 조회
+     */
+    @GetMapping("/{productId}")
+    public ResponseEntity<ApiResponseDto<ProductResponseDto>> getProduct(@PathVariable UUID productId) {
+        ProductResponseDto product = productService.getProduct(productId);
+        return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "상품 상세 정보 조회 성공", product));
     }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
@@ -1,9 +1,19 @@
 package msa.logistics.service.logistics.product.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import msa.logistics.service.logistics.common.dto.ApiResponseDto;
+import msa.logistics.service.logistics.product.dto.request.ProductCreateRequestDto;
 import msa.logistics.service.logistics.product.service.ProductService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/products")
@@ -11,5 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
     private final ProductService productService;
+
+    /**
+     * 상품 생성
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<UUID>> createProduct(@Valid @RequestBody ProductCreateRequestDto request) {
+        UUID productId = productService.createProduct(request);
+        return ResponseEntity
+                .created(URI.create("/api/v1/products/" + productId))
+                .body(new ApiResponseDto<>(HttpStatus.CREATED, "상품이 생성되었습니다.", productId));
+    }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import msa.logistics.service.logistics.common.dto.ApiResponseDto;
 import msa.logistics.service.logistics.product.dto.request.ProductCreateRequestDto;
+import msa.logistics.service.logistics.product.dto.request.ProductUpdateRequestDto;
 import msa.logistics.service.logistics.product.dto.response.ProductResponseDto;
 import msa.logistics.service.logistics.product.service.ProductService;
 import org.springframework.http.HttpStatus;
@@ -49,6 +50,7 @@ public class ProductController {
         List<ProductResponseDto> products = productService.getProductsByVendor(vendorId);
         return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "업체의 전체 상품 목록", products));
     }
+
     /**
      * 상품 수정
      */
@@ -57,6 +59,15 @@ public class ProductController {
                                                               @Valid @RequestBody ProductUpdateRequestDto request) {
         productService.updateProduct(productId, request);
         return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "상품 수정 성공", null));
+    }
+
+    /**
+     * 상품 삭제 (논리적 삭제)
+     */
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteProduct(@PathVariable UUID productId) {
+        productService.deleteProduct(productId);
+        return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "상품 삭제 성공", null));
     }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/controller/ProductController.java
@@ -49,5 +49,14 @@ public class ProductController {
         List<ProductResponseDto> products = productService.getProductsByVendor(vendorId);
         return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "업체의 전체 상품 목록", products));
     }
+    /**
+     * 상품 수정
+     */
+    @PutMapping("/{productId}")
+    public ResponseEntity<ApiResponseDto<Void>> updateProduct(@PathVariable UUID productId,
+                                                              @Valid @RequestBody ProductUpdateRequestDto request) {
+        productService.updateProduct(productId, request);
+        return ResponseEntity.ok(new ApiResponseDto<>(HttpStatus.OK, "상품 수정 성공", null));
+    }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/domain/Product.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/domain/Product.java
@@ -38,9 +38,14 @@ public class Product extends BaseEntity implements Serializable {
         this.vendorId = vendorId;
         this.hubId = hubId;
     }
+
     public void updateProduct(String productName, Long stockQuantity) {
         this.productName = productName;
         this.stockQuantity = stockQuantity;
+    }
+
+    public void markAsDeleted() {
+        this.isDelete = true;
     }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/domain/Product.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/domain/Product.java
@@ -31,17 +31,22 @@ public class Product extends BaseEntity implements Serializable {
     @Column(name = "hub_id", nullable = false)    // 관리 허브 아이디
     private UUID hubId;
 
+    @Column(name = "description")
+    private String description;
+
     @Builder
-    public Product(String productName, Long stockQuantity, UUID vendorId, UUID hubId) {
+    public Product(String productName, Long stockQuantity, UUID vendorId, UUID hubId, String description) {
         this.productName = productName;
         this.stockQuantity = stockQuantity;
         this.vendorId = vendorId;
         this.hubId = hubId;
+        this.description = description;
     }
 
-    public void updateProduct(String productName, Long stockQuantity) {
+    public void updateProduct(String productName, Long stockQuantity, String description) {
         this.productName = productName;
         this.stockQuantity = stockQuantity;
+        this.description = description;
     }
 
     public void markAsDeleted() {

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/domain/Product.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/domain/Product.java
@@ -38,5 +38,9 @@ public class Product extends BaseEntity implements Serializable {
         this.vendorId = vendorId;
         this.hubId = hubId;
     }
+    public void updateProduct(String productName, Long stockQuantity) {
+        this.productName = productName;
+        this.stockQuantity = stockQuantity;
+    }
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductCreateRequestDto.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductCreateRequestDto.java
@@ -24,11 +24,14 @@ public class ProductCreateRequestDto {
     @NotNull
     private UUID hubId;
 
+    private String description;
+
     @Builder
-    public ProductCreateRequestDto(String productName, Long stockQuantity, UUID vendorId, UUID hubId) {
+    public ProductCreateRequestDto(String productName, Long stockQuantity, UUID vendorId, UUID hubId, String description) {
         this.productName = productName;
         this.stockQuantity = stockQuantity;
         this.vendorId = vendorId;
         this.hubId = hubId;
+        this.description = description;
     }
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductCreateRequestDto.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductCreateRequestDto.java
@@ -1,0 +1,34 @@
+package msa.logistics.service.logistics.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ProductCreateRequestDto {
+    @NotBlank
+    private String productName;
+
+    @NotNull
+    private Long stockQuantity;
+
+    @NotNull
+    private UUID vendorId;
+
+    @NotNull
+    private UUID hubId;
+
+    @Builder
+    public ProductCreateRequestDto(String productName, Long stockQuantity, UUID vendorId, UUID hubId) {
+        this.productName = productName;
+        this.stockQuantity = stockQuantity;
+        this.vendorId = vendorId;
+        this.hubId = hubId;
+    }
+}

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductUpdateRequestDto.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package msa.logistics.service.logistics.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ProductUpdateRequestDto {
+    @NotBlank
+    private String productName;
+
+    @NotNull
+    private Long stockQuantity;
+
+    @NotNull
+    private UUID vendorId;
+
+    @NotNull
+    private UUID hubId;
+}

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductUpdateRequestDto.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/dto/request/ProductUpdateRequestDto.java
@@ -21,4 +21,6 @@ public class ProductUpdateRequestDto {
 
     @NotNull
     private UUID hubId;
+
+    private String description;
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/dto/response/ProductResponseDto.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/dto/response/ProductResponseDto.java
@@ -1,0 +1,27 @@
+package msa.logistics.service.logistics.product.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import msa.logistics.service.logistics.product.domain.Product;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ProductResponseDto {
+    private UUID productId;
+    private String productName;
+    private Long stockQuantity;
+    private UUID vendorId;
+    private UUID hubId;
+
+    @Builder
+    public ProductResponseDto(Product product) {
+        this.productId = product.getProductId();
+        this.productName = product.getProductName();
+        this.stockQuantity = product.getStockQuantity();
+        this.vendorId = product.getVendorId();
+        this.hubId = product.getHubId();
+    }
+}

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/dto/response/ProductResponseDto.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/dto/response/ProductResponseDto.java
@@ -15,6 +15,7 @@ public class ProductResponseDto {
     private Long stockQuantity;
     private UUID vendorId;
     private UUID hubId;
+    private String description;
 
     @Builder
     public ProductResponseDto(Product product) {
@@ -23,5 +24,6 @@ public class ProductResponseDto {
         this.stockQuantity = product.getStockQuantity();
         this.vendorId = product.getVendorId();
         this.hubId = product.getHubId();
+        this.description = product.getDescription();
     }
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/repository/ProductRepository.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/repository/ProductRepository.java
@@ -1,4 +1,13 @@
 package msa.logistics.service.logistics.product.repository;
 
-public interface ProductRepository {
+import msa.logistics.service.logistics.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProductRepository extends JpaRepository<Product, UUID> {
+    List<Product> findByVendorIdAndIsDeleteFalse(UUID vendorId);
+    Optional<Product> findByProductIdAndIsDeleteFalse(UUID productId);
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -10,7 +10,9 @@ import msa.logistics.service.logistics.product.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +40,13 @@ public class ProductService {
         Product product = productRepository.findByProductIdAndIsDeleteFalse(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
         return new ProductResponseDto(product);
+    }
+
+    // 특정 업체의 상품 목록 조회
+    public List<ProductResponseDto> getProductsByVendor(UUID vendorId) {
+        List<Product> products = productRepository.findByVendorIdAndIsDeleteFalse(vendorId);
+        return products.stream()
+                .map(ProductResponseDto::new)
+                .collect(Collectors.toList());
     }
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -1,4 +1,14 @@
 package msa.logistics.service.logistics.product.service;
 
+import lombok.RequiredArgsConstructor;
+import msa.logistics.service.logistics.product.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class ProductService {
+
+    private final ProductRepository productRepository;
+
+
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -1,8 +1,11 @@
 package msa.logistics.service.logistics.product.service;
 
 import lombok.RequiredArgsConstructor;
+import msa.logistics.service.logistics.common.exception.CustomException;
+import msa.logistics.service.logistics.common.exception.ErrorCode;
 import msa.logistics.service.logistics.product.domain.Product;
 import msa.logistics.service.logistics.product.dto.request.ProductCreateRequestDto;
+import msa.logistics.service.logistics.product.dto.response.ProductResponseDto;
 import msa.logistics.service.logistics.product.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +31,12 @@ public class ProductService {
 
         productRepository.save(product);
         return product.getProductId();
+    }
+
+    // 상품 상세 조회
+    public ProductResponseDto getProduct(UUID productId) {
+        Product product = productRepository.findByProductIdAndIsDeleteFalse(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        return new ProductResponseDto(product);
     }
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -1,8 +1,13 @@
 package msa.logistics.service.logistics.product.service;
 
 import lombok.RequiredArgsConstructor;
+import msa.logistics.service.logistics.product.domain.Product;
+import msa.logistics.service.logistics.product.dto.request.ProductCreateRequestDto;
 import msa.logistics.service.logistics.product.repository.ProductRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -10,5 +15,18 @@ public class ProductService {
 
     private final ProductRepository productRepository;
 
+    // 상품 생성
+    @Transactional
+    public UUID createProduct(ProductCreateRequestDto request) {
+        //TODO: 리팩토링 업체와 허브의 존재 여부 확인 로직 생략
+        Product product = Product.builder()
+                .productName(request.getProductName())
+                .stockQuantity(request.getStockQuantity())
+                .vendorId(request.getVendorId())
+                .hubId(request.getHubId())
+                .build();
 
+        productRepository.save(product);
+        return product.getProductId();
+    }
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -49,4 +49,12 @@ public class ProductService {
                 .map(ProductResponseDto::new)
                 .collect(Collectors.toList());
     }
+    // 상품 수정
+    @Transactional
+    public void updateProduct(UUID productId, ProductUpdateRequestDto request) {
+        Product product = productRepository.findByProductIdAndIsDeleteFalse(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.updateProduct(request.getProductName(), request.getStockQuantity());
+    }
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -5,6 +5,7 @@ import msa.logistics.service.logistics.common.exception.CustomException;
 import msa.logistics.service.logistics.common.exception.ErrorCode;
 import msa.logistics.service.logistics.product.domain.Product;
 import msa.logistics.service.logistics.product.dto.request.ProductCreateRequestDto;
+import msa.logistics.service.logistics.product.dto.request.ProductUpdateRequestDto;
 import msa.logistics.service.logistics.product.dto.response.ProductResponseDto;
 import msa.logistics.service.logistics.product.repository.ProductRepository;
 import org.springframework.stereotype.Service;
@@ -49,6 +50,7 @@ public class ProductService {
                 .map(ProductResponseDto::new)
                 .collect(Collectors.toList());
     }
+
     // 상품 수정
     @Transactional
     public void updateProduct(UUID productId, ProductUpdateRequestDto request) {
@@ -56,5 +58,14 @@ public class ProductService {
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         product.updateProduct(request.getProductName(), request.getStockQuantity());
+    }
+
+    // 상품 삭제 (논리적 삭제)
+    @Transactional
+    public void deleteProduct(UUID productId) {
+        Product product = productRepository.findByProductIdAndIsDeleteFalse(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.markAsDeleted();
     }
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -30,6 +30,7 @@ public class ProductService {
                 .stockQuantity(request.getStockQuantity())
                 .vendorId(request.getVendorId())
                 .hubId(request.getHubId())
+                .description(request.getDescription())
                 .build();
 
         productRepository.save(product);
@@ -57,7 +58,7 @@ public class ProductService {
         Product product = productRepository.findByProductIdAndIsDeleteFalse(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        product.updateProduct(request.getProductName(), request.getStockQuantity());
+        product.updateProduct(request.getProductName(), request.getStockQuantity(), request.getDescription());
     }
 
     // 상품 삭제 (논리적 삭제)

--- a/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/product/service/ProductService.java
@@ -38,6 +38,7 @@ public class ProductService {
     }
 
     // 상품 상세 조회
+    @Transactional(readOnly = true)
     public ProductResponseDto getProduct(UUID productId) {
         Product product = productRepository.findByProductIdAndIsDeleteFalse(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
@@ -45,6 +46,7 @@ public class ProductService {
     }
 
     // 특정 업체의 상품 목록 조회
+    @Transactional(readOnly = true)
     public List<ProductResponseDto> getProductsByVendor(UUID vendorId) {
         List<Product> products = productRepository.findByVendorIdAndIsDeleteFalse(vendorId);
         return products.stream()


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 필독 내용

- 엔티티 및 CRUD 기능 구현했습니다.
- 아직 허브 ID와 업체 ID와 FeignClient로 연동 전이라 추후 리팩토링 필요합니다.

## ✨ PR 세부 내용

- 상품 전체 조회/상품 상세 조회 같은 경우 논리적 삭제 적용으로 is_delete 컬럼이 false인 것만 조회 가능하도록 구현했습니다.
<!-- 수정/추가한 내용을 적어주세요. -->
