### PR TITLE
Fix: #29 테이블 명 수정 및 enum 객체 분리

### DIFF
--- a/logistics/src/main/java/msa/logistics/service/logistics/delivery/domain/Delivery.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/delivery/domain/Delivery.java
@@ -3,6 +3,7 @@ package msa.logistics.service.logistics.delivery.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import msa.logistics.service.logistics.common.entity.BaseEntity;
+import msa.logistics.service.logistics.delivery.dto.DeliveryStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -13,7 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name = "p_delivery")
+@Table(name = "p_deliveries")
 public class Delivery extends BaseEntity {
 
 
@@ -68,10 +69,6 @@ public class Delivery extends BaseEntity {
     private List<DeliveryRoute> deliveryRouteList;
 
 
-
-    public enum DeliveryStatus {
-        WAITING, IN_TRANSIT, ARRIVED, DELIVERED
-    }
 
 
 

--- a/logistics/src/main/java/msa/logistics/service/logistics/delivery/domain/DeliveryRoute.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/delivery/domain/DeliveryRoute.java
@@ -3,6 +3,7 @@ package msa.logistics.service.logistics.delivery.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import msa.logistics.service.logistics.common.entity.BaseEntity;
+import msa.logistics.service.logistics.delivery.dto.RouteStatus;
 
 import java.util.UUID;
 @Getter
@@ -11,7 +12,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name = "p_delivery_route")
+@Table(name = "p_delivery_routes")
 public class DeliveryRoute extends BaseEntity {
 
     //경로 기록 아이디
@@ -58,8 +59,6 @@ public class DeliveryRoute extends BaseEntity {
     private Delivery delivery;
 
 
-    public enum RouteStatus {
-        WAITING, IN_TRANSIT, ARRIVED, DELIVERED
-    }
+
 
 }

--- a/logistics/src/main/java/msa/logistics/service/logistics/delivery/dto/DeliveryEditRequestDto.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/delivery/dto/DeliveryEditRequestDto.java
@@ -14,7 +14,7 @@ public class DeliveryEditRequestDto {
     private String deliveryAddress;
 
     //배송 상태
-    private Delivery.DeliveryStatus deliveryStatus;
+    private DeliveryStatus deliveryStatus;
 
     // 수령인 슬랙 아이디
     private String recevierSlackId;

--- a/logistics/src/main/java/msa/logistics/service/logistics/delivery/dto/DeliveryStatus.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/delivery/dto/DeliveryStatus.java
@@ -1,0 +1,5 @@
+package msa.logistics.service.logistics.delivery.dto;
+
+public enum DeliveryStatus {
+    WAITING, IN_TRANSIT, ARRIVED, DELIVERED
+}

--- a/logistics/src/main/java/msa/logistics/service/logistics/delivery/dto/RouteStatus.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/delivery/dto/RouteStatus.java
@@ -1,0 +1,7 @@
+package msa.logistics.service.logistics.delivery.dto;
+
+
+
+public enum RouteStatus {
+    WAITING, IN_TRANSIT, ARRIVED, DELIVERED
+}

--- a/logistics/src/main/java/msa/logistics/service/logistics/delivery/service/DeliveryService.java
+++ b/logistics/src/main/java/msa/logistics/service/logistics/delivery/service/DeliveryService.java
@@ -6,6 +6,7 @@ import msa.logistics.service.logistics.delivery.domain.Delivery;
 
 import msa.logistics.service.logistics.delivery.dto.DeliveryCreateRequestDto;
 import msa.logistics.service.logistics.delivery.dto.DeliveryEditRequestDto;
+import msa.logistics.service.logistics.delivery.dto.DeliveryStatus;
 import msa.logistics.service.logistics.delivery.repository.DeliveryRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
@@ -56,7 +57,7 @@ public class DeliveryService {
         Delivery delivery = Delivery.builder()
                 .orderId(orderId)
                 .deliveryAddress(deliveryAddress)
-                .deliveryStatus(Delivery.DeliveryStatus.WAITING) // 기본값 설정
+                .deliveryStatus(DeliveryStatus.WAITING) // 기본값 설정
                 .StartHubId(startHubId)
                 .destinationHubId(destinationHubId)
                 .currentHubId(startHubId)


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 필독 내용

- Fix : 29 테이블 명 수정  , enum 객체 분리 

## ✨ PR 세부 내용
- 테이블 명을 복수로 변경 ( p_delivery -> p_deliveries) 
- Delivery 엔티티에서 enum class로 분리 

<!-- 수정/추가한 내용을 적어주세요. -->
